### PR TITLE
Fix bugs for Psr/log 3.0.2

### DIFF
--- a/src/Client/Action/ActionApi.php
+++ b/src/Client/Action/ActionApi.php
@@ -87,9 +87,9 @@ class ActionApi implements Requester, LoggerAwareInterface {
 	 *
 	 * @param LoggerInterface $logger The new Logger object.
 	 *
-	 * @return null
+	 * @return void
 	 */
-	public function setLogger( LoggerInterface $logger ) {
+	public function setLogger( LoggerInterface $logger ): void {
 		$this->logger = $logger;
 		$this->tokens->setLogger( $logger );
 	}

--- a/src/Client/Action/Tokens.php
+++ b/src/Client/Action/Tokens.php
@@ -34,9 +34,9 @@ class Tokens implements LoggerAwareInterface {
 	 *
 	 * @param LoggerInterface $logger The new Logger object.
 	 *
-	 * @return null
+	 * @return void
 	 */
-	public function setLogger( LoggerInterface $logger ) {
+	public function setLogger( LoggerInterface $logger ): void {
 		$this->logger = $logger;
 	}
 


### PR DESCRIPTION
Fix bugs that appeared in the update [Psr/log 3.0.2](#4):

* `PHP Fatal error:  Declaration of WikiConnect\MediawikiApi\Client\Action\ActionApi::setLogger(Psr\Log\LoggerInterface $logger) must be compatible with Psr\Log\LoggerAwareInterface::setLogger(Psr\Log\LoggerInterface $logger): void`

* `PHP Fatal error:  Declaration of WikiConnect\MediawikiApi\Client\Action\Tokens::setLogger(Psr\Log\LoggerInterface $logger) must be compatible with Psr\Log\LoggerAwareInterface::setLogger(Psr\Log\LoggerInterface $logger): void `